### PR TITLE
Get rid of orphans hack

### DIFF
--- a/types/system/base.go
+++ b/types/system/base.go
@@ -25,10 +25,11 @@ type ProtoVertex interface {
 
 // VertexTuple is the base storage object used by the graph engine.
 type VertexTuple struct {
-	ID       uint64
-	Vertex   StdVertex
-	InEdges  ps.Map
-	OutEdges ps.Map
+	ID         uint64
+	Incomplete bool
+	InEdges    ps.Map
+	OutEdges   ps.Map
+	Vertex     StdVertex
 }
 
 // VertexTupleVector contains an ordered list of VertexTuples. It is the return

--- a/types/system/edge.go
+++ b/types/system/edge.go
@@ -4,8 +4,9 @@ import "github.com/pipeviz/pipeviz/Godeps/_workspace/src/github.com/mndrix/ps"
 
 type StdEdge struct {
 	ID, Source, Target uint64
-	EType              EType
+	Incomplete         bool
 	Props              ps.Map
+	EType              EType
 }
 
 // EdgeVector contains an ordered list of StdEdges. It is the return value of

--- a/types/system/vertex.go
+++ b/types/system/vertex.go
@@ -9,8 +9,8 @@ import (
 // StdVertex is used to represent a vertex object by the graph engine. They exist
 // within VertexTuples.
 type StdVertex struct {
-	Type       VType  `json:"type"`
 	Properties ps.Map `json:"properties"`
+	Type       VType  `json:"type"`
 }
 
 // NewVertex creates a new Vertex object, assigning each PropPair to Props


### PR DESCRIPTION
Pursuant to the first step of #25, this PR aims to get rid of the 'orphans' hack and make the main graph fully persistent.

This'll require some changes over on the webapp side, too.